### PR TITLE
Fix/fix api issues

### DIFF
--- a/lib/data/queries.js
+++ b/lib/data/queries.js
@@ -312,18 +312,27 @@ export const addPredictions = (channel, predictions = []) => {
   return ChannelPredictions.insertMany(_predictions)
 }
 
-export const updateChannelAssets = (channelId, profileImageURL = null) => {
-  const updateProfileImage = !profileImageURL
-    ? {}
-    : { profileImageURL: profileImageURL }
-
+export const updateChannelAssets = (
+  channelId,
+  profileImageURL = null,
+  displayName = null,
+  url = null
+) => {
   return ChannelUser.updateOne(
     {
       id: channelId,
     },
     {
       $set: {
-        ...updateProfileImage,
+        ...(profileImageURL && {
+          profileImageURL,
+        }),
+        ...(displayName && {
+          displayName,
+        }),
+        ...(url && {
+          url,
+        }),
         appUpdatedAt: new Date().toISOString(),
       },
     }

--- a/lib/fetcher/commands.js
+++ b/lib/fetcher/commands.js
@@ -81,9 +81,15 @@ export const updateChannelPredictions = (login) => {
         throw new Error(`Channel ${login} not found`)
       }
 
+      if (!channel.owner) {
+        throw new Error(
+          `${channel.displayName} channel.owner not found. User may be banned or deleted`
+        )
+      }
+
       const lastPrediction = await getLastPrediction(channel.id).exec()
       const {
-        channel: _chnanel,
+        channel: _channel,
         predictions,
         updateStats,
       } = await fetchChannelData({
@@ -93,9 +99,9 @@ export const updateChannelPredictions = (login) => {
 
       const updateChannelAssetsResponse = await updateChannelAssets(
         channel.id,
-        channel.profileImageURL === _chnanel.profileImageURL
+        channel.profileImageURL === _channel.profileImageURL
           ? null
-          : _chnanel.profileImageURL
+          : _channel.profileImageURL
       )
 
       if (predictions.length) {

--- a/lib/fetcher/commands.js
+++ b/lib/fetcher/commands.js
@@ -8,7 +8,7 @@ import {
   createChannel,
   getChannels,
 } from '../data/queries'
-import { errorLogger } from '../helpers'
+import { errorLogger, compareOldField } from '../helpers'
 import { twitchRequest } from './twitch'
 import { buildCacheObject, removeCaches } from './cache'
 import {
@@ -18,7 +18,8 @@ import {
 } from './helpers'
 
 const fetchChannelData = ({
-  login,
+  channelId,
+  channelName,
   first = 25,
   after = null,
   cache = null,
@@ -27,10 +28,17 @@ const fetchChannelData = ({
   return new Promise(async (resolve, reject) => {
     try {
       const response = await twitchRequest({
-        login: login.toLowerCase(),
+        id: channelId,
+        login: channelName ? channelName.toLowerCase() : null,
         first,
         after,
       })
+
+      if (!response.channel.owner) {
+        throw new Error(
+          `${channelName} channel.owner not found. User may be banned or deleted`
+        )
+      }
 
       const data = mergeResponseData(response, cache, first, lastPrediction)
 
@@ -53,7 +61,8 @@ const fetchChannelData = ({
         resolve(data)
       } else {
         const nextVariables = {
-          login,
+          channelId,
+          channelName,
           first,
           after: data.nextCursor,
         }
@@ -81,27 +90,25 @@ export const updateChannelPredictions = (login) => {
         throw new Error(`Channel ${login} not found`)
       }
 
-      if (!channel.owner) {
-        throw new Error(
-          `${channel.displayName} channel.owner not found. User may be banned or deleted`
-        )
-      }
-
       const lastPrediction = await getLastPrediction(channel.id).exec()
       const {
         channel: _channel,
         predictions,
         updateStats,
       } = await fetchChannelData({
-        login: channel.displayName,
+        channelId: channel.id,
         lastPrediction,
       })
 
+      const newProfileImageURL = compareOldField(
+        channel.profileImageURL,
+        _channel.profileImageURL
+      )
       const updateChannelAssetsResponse = await updateChannelAssets(
         channel.id,
-        channel.profileImageURL === _channel.profileImageURL
-          ? null
-          : _channel.profileImageURL
+        newProfileImageURL,
+        compareOldField(channel.displayName, _channel.displayName),
+        compareOldField(channel.url, _channel.url)
       )
 
       if (predictions.length) {
@@ -141,6 +148,7 @@ export const updateChannelPredictions = (login) => {
       resolve({
         nb: predictions.length,
         message: `${predictions.length} new predictions`,
+        newProfileImageURL,
       })
     } catch (error) {
       reject(errorLogger('updateChannelPredictions', error))
@@ -148,15 +156,15 @@ export const updateChannelPredictions = (login) => {
   })
 }
 
-export const initializeChannel = (login, flushCache = true) => {
+export const initializeChannel = (channelName, flushCache = true) => {
   return new Promise(async (resolve, reject) => {
     try {
-      const checkChannel = await getChannel(login).exec()
+      const checkChannel = await getChannel(channelName).exec()
 
       if (checkChannel) {
         throw new Error('Channel already in database')
       } else {
-        const data = await fetchChannelData({ login })
+        const data = await fetchChannelData({ channelName })
         const channel = await createChannel(data.channel).save()
         const predictions = await addPredictions(channel, data.predictions)
 
@@ -186,12 +194,17 @@ export const updateChannelsPredictions = () => {
           channel.displayName
         ).catch(console.log)
 
-        if (response && response.nb > 0) {
-          newPredictions += response.nb
+        console.log(response)
 
+        if (response && response.newProfileImageURL) {
           removeCachesPattern.push(
             buildCacheObject('channel', { login: channel.displayName })
           )
+        }
+
+        if (response && response.nb > 0) {
+          newPredictions += response.nb
+
           removeCachesPattern.push(
             buildCacheObject('channel.stats', { login: channel.displayName })
           )

--- a/lib/fetcher/twitch.js
+++ b/lib/fetcher/twitch.js
@@ -14,8 +14,13 @@ export const FETCH_PREDICTIONS_QUERY = gql`
     displayName
   }
 
-  query GetChannelPredictions($login: String!, $after: Cursor, $first: Int!) {
-    channel(name: $login) {
+  query GetChannelPredictions(
+    $id: ID
+    $login: String
+    $after: Cursor
+    $first: Int!
+  ) {
+    channel(id: $id, name: $login) {
       id
       displayName
       url

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,6 +2,10 @@ import isEqual from 'lodash/isEqual'
 import isObject from 'lodash/isObject'
 import transform from 'lodash/transform'
 
+export const compareOldField = (oldField, newField) => {
+  return newField !== oldField && newField
+}
+
 // @source https://gist.github.com/Yimiprod/7ee176597fef230d1451
 export function difference(object, base) {
   function changes(object, base) {


### PR DESCRIPTION
- [x] When a user is banned or deleted the response do not return the field `channel.owner` but the object still exists in twitch database.
- [x] Query by channel id and not channel name when updates are done
- [x] When a user changes his display name, update the appropriate value in db